### PR TITLE
Quick Fix of the Plus Button

### DIFF
--- a/piktorlog/src/App.js
+++ b/piktorlog/src/App.js
@@ -35,17 +35,20 @@ const PageContent = styled.main`
   max-width: 1200px;
 `;
 
-function App({ checkLogin, logout, getUserAlbums }) {
+function App({ checkLogin, logout, showButton }) {
   const [actionToggle, setActionToggle] = useState(false);
   const handleButtonClick = () => setActionToggle(!actionToggle);
 
   const [checkingLogin, setCheckingLogin] = useState(true);
- 
-  //Where do I make the get request? How do I make the get request?
+  
   useEffect(() => {
     checkLogin();
     setCheckingLogin(false);
+    
+  
   }, [checkLogin]);
+
+
 
   if (checkingLogin) {
     // probably replace this with a spinner or some nicer looking loading indicator
@@ -92,11 +95,21 @@ function App({ checkLogin, logout, getUserAlbums }) {
         </button>
         <RequestDebug />
       </div>
-      <Link to={`/createAlbum`}><ActionButton active={actionToggle} handleClick={handleButtonClick} /></Link>
+      {
+        showButton && (<Link to={`/createAlbum`}>
+        <ActionButton active={actionToggle} handleClick={handleButtonClick} disabled ={showButton ? true:false} />
+      </Link>)
+      }
+      
+  
     </AppWrapper>
   );
 };
 
-
+const mapStateToProps = ({ currentUser }) => {
+  return {
+    showButton: !!currentUser
+  }
+};
 //Missing map state to props bit
-export default connect(null, { checkLogin, logout, getUserAlbums })(App);
+export default connect(mapStateToProps, { checkLogin, logout, getUserAlbums})(App);

--- a/piktorlog/src/App.js
+++ b/piktorlog/src/App.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Switch, Route } from 'react-router-dom';
+import { Switch, Route, Link } from 'react-router-dom';
 import styled from 'styled-components';
 import { connect } from 'react-redux';
 
@@ -92,7 +92,7 @@ function App({ checkLogin, logout, getUserAlbums }) {
         </button>
         <RequestDebug />
       </div>
-      <ActionButton active={actionToggle} handleClick={handleButtonClick} />
+      <Link to={`/createAlbum`}><ActionButton active={actionToggle} handleClick={handleButtonClick} /></Link>
     </AppWrapper>
   );
 };


### PR DESCRIPTION
# Description
Made the plus button at the bottom which exists at the level of App.js a "<Link>" which takes you directly to the CreateAlbum page if you are logged in (otherwise you stay on the login page). 

The plus button will only show up if you are logged in (thanks to @Brodt7258 for the assist); if you are not logged in, the plus button (which links to the Create Album page) should not show.

Fixes # (issue)

## Type of change
- [X] New feature (non-breaking change which adds functionality)
- [X ] This change requires a documentation update

## Change Status

- [X ] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# Checklist

- [X ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] There are no merge conflicts
